### PR TITLE
Integrate Idea step into wizard

### DIFF
--- a/cypress/e2e/simulation.spec.ts
+++ b/cypress/e2e/simulation.spec.ts
@@ -29,6 +29,11 @@ describe('AI wizard simulation', () => {
     cy.get('ul li').should('have.length', 1);
     cy.contains('Next').click();
 
+    // Idea step
+    cy.contains('Describe your business idea in detail');
+    cy.get('textarea').type('My awesome idea.');
+    cy.contains('Next').click();
+
     // Marketing step should show captions/hashtags
     cy.contains('Captions');
     cy.contains('Hashtags');

--- a/src/features/wizard/__tests__/IdeaStep.test.tsx
+++ b/src/features/wizard/__tests__/IdeaStep.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import IdeaStep, { type IdeaHandles } from '../IdeaStep';
+
+function setup() {
+  const ref = React.createRef<IdeaHandles>();
+  render(<IdeaStep ref={ref} />);
+  return { ref };
+}
+
+test('validates idea input and returns data', () => {
+  const { ref } = setup();
+  fireEvent.change(screen.getByPlaceholderText(/enter your full vision/i), { target: { value: 'Great idea' } });
+  let valid = false;
+  act(() => {
+    valid = ref.current!.isValid();
+  });
+  expect(valid).toBe(true);
+  expect(ref.current!.getData()).toEqual({ idea: 'Great idea' });
+});
+
+test('shows error when empty', () => {
+  const { ref } = setup();
+  let valid = true;
+  act(() => {
+    valid = ref.current!.isValid();
+  });
+  expect(valid).toBe(false);
+  expect(screen.getByText(/please describe your idea/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- insert new IdeaStep after pricing step in `WizardFlow`
- adjust navigation logic to store the idea text
- bump wizard to 5 steps and update the progress bar
- expand Cypress flow to handle the new step
- add unit test for `IdeaStep`

## Testing
- `npx jest` *(fails: Preset ts-jest not found)*
- `npx cypress run` *(fails: needs to install cypress)*

------
https://chatgpt.com/codex/tasks/task_e_6845956f658483338f5601755b573be9